### PR TITLE
Update `fixest` usage in vignette

### DIFF
--- a/vignettes/summclust.Rmd
+++ b/vignettes/summclust.Rmd
@@ -64,14 +64,12 @@ Note that you can also use CVR3 and CRV3J covariance matrices computed via `summ
 
 ```{r, warning = FALSE, message=FALSE}
 library(lmtest)
-library(fixest)
 
 vcov3J <- 
-vcov_CR3J(
-  lm_fit, 
-  cluster = ~ ind_code
-)
-
+  vcov_CR3J(
+    lm_fit, 
+    cluster = ~ ind_code
+  )
 
 all.equal(
   vcov3J, 
@@ -81,26 +79,32 @@ all.equal(
 df <- length(summclust_res$cluster) - 1
 
 # with lmtest
-CRV1 <- coeftest(lm_fit, sandwich::vcovCL(lm_fit, ~ind_code), df = df)
-CRV3 <- coeftest(lm_fit, vcov3J, df = df)
+CRV1 <- lmtest::coeftest(lm_fit, sandwich::vcovCL(lm_fit, ~ind_code), df = df)
+CRV3 <- lmtest::coeftest(lm_fit, vcov3J, df = df)
 
 CRV1[c("union", "race", "msp"),]
 CRV3[c("union", "race", "msp"),]
 
-confint(CRV1)[c("union", "race", "msp"),]
-confint(CRV3)[c("union", "race", "msp"),]
+lmtest::confint(CRV1)[c("union", "race", "msp"),]
+lmtest::confint(CRV3)[c("union", "race", "msp"),]
+```
 
-# with fixest
+```{r}
+library(fixest)
+
 feols_fit <- feols(
-  ln_wage ~ as.factor(grade) + as.factor(age) + as.factor(birth_yr) + union +  race + msp,
-  data = nlswork)
+  ln_wage ~ i(grade) + i(age) + i(birth_yr) + union +  race + msp,
+  data = nlswork
+)
 
-fixest::coeftable(
-  feols_fit,
-  vcov = summclust_res$vcov,
-  ssc = ssc(adj = FALSE, cluster.adj = FALSE)
-)[c("msp", "union", "race"),]
+# Store vcov into the fixest object
+feols_fit <- summary(
+  feols_fit, 
+  vcov = vcov_CR3J(feols_fit, cluster = ~ ind_code)
+)
 
+# Now it just works with fixest functions
+fixest::coeftable(feols_fit, keep = c("msp", "union", "race"))
 ```
 
 The p-value and confidence intervals for `fixest::coeftable()` differ from `lmtest::coeftest()` and `summclust::coeftable()`. This is due to the fact that `fixest::coeftable()` uses a different degree of freedom for the t-distribution used in these calculation (I believe it uses t(N-1)).


### PR DESCRIPTION
Here is a quick update to the vignette. One of my favorite things (I learnt this working on did2s) about fixest is if you call `summary` with a new vcov, it returns a new fixest object with the updated vcov matrix. Then you can just use it with all the commands. It's kind of nice to have that for people to see in the docs?

```{r}
library(fixest)

feols_fit <- feols(
  ln_wage ~ i(grade) + i(age) + i(birth_yr) + union +  race + msp,
  data = nlswork
)

# Store vcov into the fixest object
feols_fit <- summary(
  feols_fit, 
  vcov = vcov_CR3J(feols_fit, cluster = ~ ind_code)
)

# Now it just works with fixest functions
fixest::coeftable(feols_fit, keep = c("msp", "union", "race"))
```