### PR TITLE
Adapt tests to fixest v0.13.0

### DIFF
--- a/tests/testthat/test-r-vs-stata.R
+++ b/tests/testthat/test-r-vs-stata.R
@@ -167,7 +167,7 @@ test_that("test against stata - leverage, fixef absorb", {
 
   feols_fit <- feols(ln_wage ~ union + race + msp |
                        grade + age + birth_yr + ind_code,
-                     data = df2)
+                     data = df2, fixef.rm = "none")
 
   lm_fit <- lm(
     ln_wage ~ union + race + msp + as.factor(grade) + as.factor(age) +


### PR DESCRIPTION
Hey @kylebutts and @s3alfisc,

`fixest` v0.13.0, introduces a few breaking changes. 
One is that the new default is to remove the fixed-effects singletons. 

I have added the argument `fixef.rm = "none"` to a test in [tests/testthat/test-r-vs-stata.R](https://github.com/s3alfisc/summclust/compare/main...lrberge:patch-1?expand=1#diff-00963b25e29915b9fd89b15ba8e5246bff1254b341637fde4032c7be63d78627).

Indeed, in that test the new default leads to the removal of one observation, which was not the case previously, hence 3 tests not passing.

I don't think there is another side-effect on this project.
Thanks!